### PR TITLE
Add complete season NFOs with titles, descriptions, and Jellyfin-safe season numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/One Pace/[One Pace][1-7] Romance Dawn [1080p]/season.nfo
+++ b/One Pace/[One Pace][1-7] Romance Dawn [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Romance Dawn</title>
+  <sorttitle>01</sorttitle>
+  <seasonnumber>1</seasonnumber>
+  <displayseason>1</displayseason>
   <plot>Monkey D. Luffy sets out on an adventure to form a crew, find the legendary One Piece, and become the pirate king.</plot>
-  <outline>Monkey D. Luffy sets out on an adventure to form a crew, find the legendary One Piece, and become the pirate king.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>1-7 Romance Dawn</title>
-  <sorttitle>1</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][1-7] Romance Dawn [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][101-105] Reverse Mountain [1080p]/season.nfo
+++ b/One Pace/[One Pace][101-105] Reverse Mountain [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Reverse Mountain</title>
+  <sorttitle>08</sorttitle>
+  <seasonnumber>10</seasonnumber>
+  <displayseason>10</displayseason>
   <plot>Reverse Mountain is the entrance to the Grand Line. What await the Straw Hats are impossible water currents, a giant whale, and dubious people going by codenames.</plot>
-  <outline>Reverse Mountain is the entrance to the Grand Line. What await the Straw Hats are impossible water currents, a giant whale, and dubious people going by codenames.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>101-105 Reverse Mountain</title>
-  <sorttitle>8</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][101-105] Reverse Mountain [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][1058-] Egghead [1080p]/season.nfo
+++ b/One Pace/[One Pace][1058-] Egghead [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Futuristic tech, giant alien monsters, battle robots, superhuman clones... Who are all these people calling themselves Dr. Vegapunk, and why is the government after one of their own?</plot>
-  <outline>Futuristic tech, giant alien monsters, battle robots, superhuman clones... Who are all these people calling themselves Dr. Vegapunk, and why is the government after one of their own?</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>1058-1xxxx Egghead</title>
+  <title>Egghead</title>
   <sorttitle>33</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][1058-] Egghead [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>36</seasonnumber>
+  <displayseason>36</displayseason>
+  <plot>Futuristic tech, giant alien monsters, battle robots, superhuman clones... Who are all these people calling themselves Dr. Vegapunk, and why is the government after one of their own?</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][106-114] Whiskey Peak [480p]/season.nfo
+++ b/One Pace/[One Pace][106-114] Whiskey Peak [480p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Whiskey Peak</title>
+  <sorttitle>09</sorttitle>
+  <seasonnumber>11</seasonnumber>
+  <displayseason>11</displayseason>
   <plot>The first island on the Grand Line is surprisingly welcoming to pirates. But as night falls, a deadly plot unravels.</plot>
-  <outline>The first island on the Grand Line is surprisingly welcoming to pirates. But as night falls, a deadly plot unravels.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>106-114 Whiskey Peak</title>
-  <year>2017</year>
-  <sorttitle>9</sorttitle>
-  <premiered>2017-08-19</premiered>
-  <releasedate>2017-08-19</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][106-114] Whiskey Peak [480p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][115-129] Little Garden [1080p]/season.nfo
+++ b/One Pace/[One Pace][115-129] Little Garden [1080p]/season.nfo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<season>
+  <title>Little Garden</title>
+  <sorttitle>10</sorttitle>
+  <seasonnumber>12</seasonnumber>
+  <displayseason>12</displayseason>
+  <plot>The Straw Hats vow to bring Princess Vivi to Arabasta, and their journey brings them to Little Garden, an island from prehistoria that is home to creatures and people larger than life.</plot>
+  <lockdata>false</lockdata>
+</season>

--- a/One Pace/[One Pace][130-154] Drum Island [1080p]/season.nfo
+++ b/One Pace/[One Pace][130-154] Drum Island [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>When Nami falls ill, the crew makes a detour from Arabasta to seek medical help. They happen upon a winter island inhabited by a distrusting populace and a single doctor with a mysterious reindeer companion.</plot>
-  <outline>When Nami falls ill, the crew makes a detour from Arabasta to seek medical help. They happen upon a winter island inhabited by a distrusting populace and a single doctor with a mysterious reindeer companion.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>130-154 Drum Island</title>
-  <year>2021</year>
+  <title>Drum Island</title>
   <sorttitle>11</sorttitle>
-  <premiered>2021-02-05</premiered>
-  <releasedate>2021-02-05</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][130-154] Drum Island [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>13</seasonnumber>
+  <displayseason>13</displayseason>
+  <plot>When Nami falls ill, the crew makes a detour from Arabasta to seek medical help. They happen upon a winter island inhabited by a distrusting populace and a single doctor with a mysterious reindeer companion.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][155-217] Arabasta [1080p]/season.nfo
+++ b/One Pace/[One Pace][155-217] Arabasta [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Arabasta teeters on the edge of civil war, and it's up to Princess Vivi and the Straw Hats to stem the rebellion, uncover the plot of Baroque Works, and beat the Warlord Crocodile.</plot>
-  <outline>Arabasta teeters on the edge of civil war, and it's up to Princess Vivi and the Straw Hats to stem the rebellion, uncover the plot of Baroque Works, and beat the Warlord Crocodile.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>155-217 Arabasta</title>
-  <year>2021</year>
+  <title>Arabasta</title>
   <sorttitle>12</sorttitle>
-  <premiered>2021-05-10</premiered>
-  <releasedate>2021-05-10</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][155-217] Arabasta [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>14</seasonnumber>
+  <displayseason>14</displayseason>
+  <plot>Arabasta teeters on the edge of civil war, and it's up to Princess Vivi and the Straw Hats to stem the rebellion, uncover the plot of Baroque Works, and beat the Warlord Crocodile.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][218-236] Jaya [1080p]/season.nfo
+++ b/One Pace/[One Pace][218-236] Jaya [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The Straw Hats seek the fabled sky island Skypiea and head to Jaya for information on its whereabouts. Their convictions are tested by the pirates of Mock Town, but not everyone on the island is a hardline skeptic.</plot>
-  <outline>The Straw Hats seek the fabled sky island Skypiea and head to Jaya for information on its whereabouts. Their convictions are tested by the pirates of Mock Town, but not everyone on the island is a hardline skeptic.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>218-236 Jaya</title>
+  <title>Jaya</title>
   <sorttitle>13</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][218-236] Jaya [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>15</seasonnumber>
+  <displayseason>15</displayseason>
+  <plot>The Straw Hats seek the fabled sky island Skypiea and head to Jaya for information on its whereabouts. Their convictions are tested by the pirates of Mock Town, but not everyone on the island is a hardline skeptic.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][23-41] Syrup Village [1080p]/season.nfo
+++ b/One Pace/[One Pace][23-41] Syrup Village [1080p]/season.nfo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<season>
+  <title>Syrup Village</title>
+  <sorttitle>03</sorttitle>
+  <seasonnumber>3</seasonnumber>
+  <displayseason>3</displayseason>
+  <plot>Luffy’s fledgling pirate crew arrives at the slopes of Syrup Village. There they find a liar and a conspiracy to steal a young lady’s fortune.</plot>
+  <lockdata>false</lockdata>
+</season>

--- a/One Pace/[One Pace][237-303] Skypiea [1080p]/season.nfo
+++ b/One Pace/[One Pace][237-303] Skypiea [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Arriving at Skypiea, the Straw Hats are instantly met with unfamiliar sights, objects, and customs. What's more, the god of the sky island deems the Blue Sea dwellers to be trespassing and casts his judgment upon them.</plot>
-  <outline>Arriving at Skypiea, the Straw Hats are instantly met with unfamiliar sights, objects, and customs. What's more, the god of the sky island deems the Blue Sea dwellers to be trespassing and casts his judgment upon them.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>237-303 Skypiea</title>
+  <title>Skypiea</title>
   <sorttitle>14</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][237-303] Skypiea [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>16</seasonnumber>
+  <displayseason>16</displayseason>
+  <plot>Arriving at Skypiea, the Straw Hats are instantly met with unfamiliar sights, objects, and customs. What’s more, the god of the sky island deems the Blue Sea dwellers to be trespassing and casts his judgment upon them.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][304-321] Long Ring Long Land [720p]/season.nfo
+++ b/One Pace/[One Pace][304-321] Long Ring Long Land [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>On Long Ring Long Land, the Straw Hats are challenged to a Davy Back Fight. As they dive headfirst into a series of games with serious outcomes, the best the Navy has to offer has meanwhile begun to pay closer attention to certain Straw Hat crewmembers.</plot>
-  <outline>On Long Ring Long Land, the Straw Hats are challenged to a Davy Back Fight. As they dive headfirst into a series of games with serious outcomes, the best the Navy has to offer has meanwhile begun to pay closer attention to certain Straw Hat crewmembers.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>304-321 Long Ring Long Land</title>
-  <year>2016</year>
+  <title>Long Ring Long Land</title>
   <sorttitle>15</sorttitle>
-  <premiered>2016-10-29</premiered>
-  <releasedate>2016-10-29</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][304-321] Long Ring Long Land [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>17</seasonnumber>
+  <displayseason>17</displayseason>
+  <plot>On Long Ring Long Land, the Straw Hats are challenged to a Davy Back Fight. As they dive headfirst into a series of games with serious outcomes, the best the Navy has to offer has meanwhile begun to pay closer attention to certain Straw Hat crewmembers.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][322-374] Water Seven [1080p]/season.nfo
+++ b/One Pace/[One Pace][322-374] Water Seven [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The Straw Hats make landfall at the glorious city of Water Seven, known worldwide for its unparalleled shipyards. The pirates go to inquire about repairs for their ship, but the city threatens to take their money, their ship, and their crewmates.</plot>
-  <outline>The Straw Hats make landfall at the glorious city of Water Seven, known worldwide for its unparalleled shipyards. The pirates go to inquire about repairs for their ship, but the city threatens to take their money, their ship, and their crewmates.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>322-374 Water Seven</title>
-  <year>2020</year>
+  <title>Water Seven</title>
   <sorttitle>16</sorttitle>
-  <premiered>2020-09-04</premiered>
-  <releasedate>2020-09-04</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][322-374] Water Seven [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>18</seasonnumber>
+  <displayseason>18</displayseason>
+  <plot>The Straw Hats make landfall at the glorious city of Water Seven, known worldwide for its unparalleled shipyards. The pirates go to inquire about repairs for their ship, but the city threatens to take their money, their ship, and their crewmates.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][35-75] The Adventures of Buggy's Crew [1080p]/season.nfo
+++ b/One Pace/[One Pace][35-75] The Adventures of Buggy's Crew [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>The Adventures of Buggy's Crew</title>
+  <sorttitle>03.5</sorttitle>
+  <seasonnumber>4</seasonnumber>
+  <displayseason>4</displayseason>
   <plot>Buggy, after being defeated by Luffy, Zoro, and Nami, begins his quest to regain his body parts and his crew, and then he will get his flashy revenge on Luffy.</plot>
-  <outline>Buggy, after being defeated by Luffy, Zoro, and Nami, begins his quest to regain his body parts and his crew, and then he will get his flashy revenge on Luffy.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>35-75 The Adventures of Buggy's Crew</title>
-  <sorttitle>6.5</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][35-75] The Adventures of Buggy's Crew [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][375-430] Enies Lobby [1080p]/season.nfo
+++ b/One Pace/[One Pace][375-430] Enies Lobby [1080p]/season.nfo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<season>
+  <title>Enies Lobby</title>
+  <sorttitle>17</sorttitle>
+  <seasonnumber>19</seasonnumber>
+  <displayseason>19</displayseason>
+  <plot>In order to free Nico Robin from the clutches of the World Government, the Straw Hats and their allies must invade the judicial island, Enies Lobby, and take on the government’s premiere clandestine unit: CP9.</plot>
+  <lockdata>false</lockdata>
+</season>

--- a/One Pace/[One Pace][42,22] Gaimon [1080p]/season.nfo
+++ b/One Pace/[One Pace][42,22] Gaimon [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Gaimon</title>
+  <sorttitle>04</sorttitle>
+  <seasonnumber>5</seasonnumber>
+  <displayseason>5</displayseason>
   <plot>With Usopp now on the crew and their new ship, the Going Merry, under their command, the Straw Hats head to an island said to hold a fabled treasure. There they encounter a strange man stuck in a box who has been looking for the same treasure.</plot>
-  <outline>With Usopp now on the crew and their new ship, the Going Merry, under their command, the Straw Hats head to an island said to hold a fabled treasure. There they encounter a strange man stuck in a box who has been looking for the same treasure.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>42-22 Gaimon</title>
-  <sorttitle>4</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][42,22] Gaimon [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][42-68] Baratie [1080p]/season.nfo
+++ b/One Pace/[One Pace][42-68] Baratie [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Baratie</title>
+  <sorttitle>05</sorttitle>
+  <seasonnumber>6</seasonnumber>
+  <displayseason>6</displayseason>
   <plot>The Straw Hats head to the ocean-going restaurant, Baratie, with the hopes of recruiting one of their cooks. In the meantime, hungry yet powerful forces gather to lay siege to the restaurant — all while a menacing swordsman from the Grand Line steadily approaches.</plot>
-  <outline>The Straw Hats head to the ocean-going restaurant, Baratie, with the hopes of recruiting one of their cooks. In the meantime, hungry yet powerful forces gather to lay siege to the restaurant — all while a menacing swordsman from the Grand Line steadily approaches.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>42-68 Baratie</title>
-  <sorttitle>5</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][42-68] Baratie [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][431-441] Post-Enies Lobby [720p]/season.nfo
+++ b/One Pace/[One Pace][431-441] Post-Enies Lobby [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The Straw Hats return to Water Seven after the ordeal at Enies Lobby. While there, they are met by a familial vice admiral, and they await news of their new ship.</plot>
-  <outline>The Straw Hats return to Water Seven after the ordeal at Enies Lobby. While there, they are met by a familial vice admiral, and they await news of their new ship.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>431-441 Post-Enies Lobby</title>
-  <year>2013</year>
+  <title>Post-Enies Lobby</title>
   <sorttitle>18</sorttitle>
-  <premiered>2013-07-06</premiered>
-  <releasedate>2013-07-06</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][431-441] Post-Enies Lobby [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>20</seasonnumber>
+  <displayseason>20</displayseason>
+  <plot>The Straw Hats return to Water Seven after the ordeal at Enies Lobby. While there, they are met by a familial vice admiral, and they await news of their new ship.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][442-489] Thriller Bark [720p]/season.nfo
+++ b/One Pace/[One Pace][442-489] Thriller Bark [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The Straw Hats' next destination is Fishman Island, but first they must traverse the dreaded Florian Triangle which is known for many eerie and mysterious things such as disappearing crews, conversational skeletons, and a floating island full of zombies and other horrors.</plot>
-  <outline>The Straw Hats' next destination is Fishman Island, but first they must traverse the dreaded Florian Triangle which is known for many eerie and mysterious things such as disappearing crews, conversational skeletons, and a floating island full of zombies and other horrors.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>442-489 Thriller Bark</title>
-  <year>2013</year>
+  <title>Thriller Bark</title>
   <sorttitle>19</sorttitle>
-  <premiered>2013-08-24</premiered>
-  <releasedate>2013-08-24</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][442-489] Thriller Bark [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>21</seasonnumber>
+  <displayseason>21</displayseason>
+  <plot>The Straw Hats' next destination is Fishman Island, but first they must traverse the dreaded Florian Triangle which is known for many eerie and mysterious things such as disappearing crews, conversational skeletons, and a floating island full of zombies and other horrors.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][490-513] Sabaody Archipelago [720p]/season.nfo
+++ b/One Pace/[One Pace][490-513] Sabaody Archipelago [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The second half of the Grand Line lays just ahead, so the Straw Hats stop at Sabaody Archipelago to plan the way forward. But being so close to the Holy Land and Navy Headquarters, Luffy's crew comes face-to-face with the darkest forces of the World Government.</plot>
-  <outline>The second half of the Grand Line lays just ahead, so the Straw Hats stop at Sabaody Archipelago to plan the way forward. But being so close to the Holy Land and Navy Headquarters, Luffy's crew comes face-to-face with the darkest forces of the World Government.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>490-513 Sabaody Archipelago</title>
-  <year>2016</year>
+  <title>Sabaody Archipelago</title>
   <sorttitle>20</sorttitle>
-  <premiered>2016-01-23</premiered>
-  <releasedate>2016-01-23</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][490-513] Sabaody Archipelago [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>22</seasonnumber>
+  <displayseason>22</displayseason>
+  <plot>The second half of the Grand Line lays just ahead, so the Straw Hats stop at Sabaody Archipelago to plan the way forward. But being so close to the Holy Land and Navy Headquarters, Luffy's crew comes face-to-face with the darkest forces of the World Government.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][514-524] Amazon Lily [720p]/season.nfo
+++ b/One Pace/[One Pace][514-524] Amazon Lily [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Luffy is separated from his crew, and he finds himself on an unfamiliar island in the middle of the Calm Belt... an island inhabited only by women where men are prohibited from entering.</plot>
-  <outline>Luffy is separated from his crew, and he finds himself on an unfamiliar island in the middle of the Calm Belt... an island inhabited only by women where men are prohibited from entering.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>514-524 Amazon Lily</title>
-  <year>2016</year>
+  <title>Amazon Lily</title>
   <sorttitle>21</sorttitle>
-  <premiered>2016-01-27</premiered>
-  <releasedate>2016-01-27</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][514-524] Amazon Lily [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>23</seasonnumber>
+  <displayseason>23</displayseason>
+  <plot>Luffy is separated from his crew, and he finds himself on an unfamiliar island in the middle of the Calm Belt... an island inhabited only by women where men are prohibited from entering.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][525-548] Impel Down [720p]/season.nfo
+++ b/One Pace/[One Pace][525-548] Impel Down [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Luffy launches a daring rescue mission to break his big brother Ace from the government prison, Impel Down. It's a race to the prison's lowest levels — a literal journey through hell itself.</plot>
-  <outline>Luffy launches a daring rescue mission to break his big brother Ace from the government prison, Impel Down. It's a race to the prison's lowest levels — a literal journey through hell itself.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>525-548 Impel Down</title>
-  <year>2016</year>
+  <title>Impel Down</title>
   <sorttitle>22</sorttitle>
-  <premiered>2016-12-15</premiered>
-  <releasedate>2016-12-15</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][525-548] Impel Down [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>24</seasonnumber>
+  <displayseason>24</displayseason>
+  <plot>Luffy launches a daring rescue mission to break his big brother Ace from the government prison, Impel Down. It's a race to the prison's lowest levels — a literal journey through hell itself.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][543-560] The Adventures of the Straw Hats [1080p]/season.nfo
+++ b/One Pace/[One Pace][543-560] The Adventures of the Straw Hats [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Somewhere in the world... Sanji resists, while Robin meets terrible people. Franky's not himself, and Usopp learns to survive. Chopper avoids becoming food, and Nami reports on the weather. Brook is repaid in underpants, and Zoro... is lost and annoyed.</plot>
-  <outline>Somewhere in the world... Sanji resists, while Robin meets terrible people. Franky's not himself, and Usopp learns to survive. Chopper avoids becoming food, and Nami reports on the weather. Brook is repaid in underpants, and Zoro... is lost and annoyed.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>543-560 The Adventures of the Straw Hats</title>
+  <title>The Adventures of the Straw Hats</title>
   <sorttitle>22.5</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][543-560] The Adventures of the Straw Hats [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>25</seasonnumber>
+  <displayseason>25</displayseason>
+  <plot>Somewhere in the world... Sanji resists, while Robin meets terrible people. Franky's not himself, and Usopp learns to survive. Chopper avoids becoming food, and Nami reports on the weather. Brook is repaid in underpants, and Zoro... is lost and annoyed.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][549-580] Marineford [720p]/season.nfo
+++ b/One Pace/[One Pace][549-580] Marineford [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Pirate Whitebeard and his allies on one side; the Navy and its Seven Warlords on the other. At the center of it all: Portgas D. Ace and his unspeakable past and heritage. Luffy races to Ace's execution scaffold as a battle between the world's most powerful people unfolds.</plot>
-  <outline>Pirate Whitebeard and his allies on one side; the Navy and its Seven Warlords on the other. At the center of it all: Portgas D. Ace and his unspeakable past and heritage. Luffy races to Ace's execution scaffold as a battle between the world's most powerful people unfolds.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>549-580 Marineford</title>
-  <year>2020</year>
+  <title>Marineford</title>
   <sorttitle>23</sorttitle>
-  <premiered>2020-10-06</premiered>
-  <releasedate>2020-10-06</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][549-580] Marineford [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>26</seasonnumber>
+  <displayseason>26</displayseason>
+  <plot>Pirate Whitebeard and his allies on one side; the Navy and its Seven Warlords on the other. At the center of it all: Portgas D. Ace and his unspeakable past and heritage. Luffy races to Ace's execution scaffold as a battle between the world's most powerful people unfolds.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][581-597] Post-War [1080p]/season.nfo
+++ b/One Pace/[One Pace][581-597] Post-War [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The war has taken its toll on the world, and Luffy reminisces about younger days when he first met Ace and became his brother. To become strong enough to withstand the New World, Luffy must make a critical decision for himself and his crew.</plot>
-  <outline>The war has taken its toll on the world, and Luffy reminisces about younger days when he first met Ace and became his brother. To become strong enough to withstand the New World, Luffy must make a critical decision for himself and his crew.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>581-597 Post-War</title>
-  <year>2020</year>
+  <title>Post-War</title>
   <sorttitle>24</sorttitle>
-  <premiered>2020-07-23</premiered>
-  <releasedate>2020-07-23</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][581-597] Post-War [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>27</seasonnumber>
+  <displayseason>27</displayseason>
+  <plot>The war has taken its toll on the world, and Luffy reminisces about younger days when he first met Ace and became his brother. To become strong enough to withstand the New World, Luffy must make a critical decision for himself and his crew.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][598-602] Return to Sabaody [1080p]/season.nfo
+++ b/One Pace/[One Pace][598-602] Return to Sabaody [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Two years have passed since the Straw Hats were forcibly separated, and they reconvene back at Sabaody stronger and even more committed to the journey ahead.</plot>
-  <outline>Two years have passed since the Straw Hats were forcibly separated, and they reconvene back at Sabaody stronger and even more committed to the journey ahead.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>598-602 Return to Sabaody</title>
+  <title>Return to Sabaody</title>
   <sorttitle>25</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][598-602] Return to Sabaody [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>28</seasonnumber>
+  <displayseason>28</displayseason>
+  <plot>Two years have passed since the Straw Hats were forcibly separated, and they reconvene back at Sabaody stronger and even more committed to the journey ahead.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][603-653] Fishman Island [720p]/season.nfo
+++ b/One Pace/[One Pace][603-653] Fishman Island [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The path the to the New World takes the Straw Hats thousands of leagues under the sea to the underwater Fishman Island. However, the island's dark past is reaching a breaking point, and Luffy and his crew are caught in the middle of the conflict.</plot>
-  <outline>The path the to the New World takes the Straw Hats thousands of leagues under the sea to the underwater Fishman Island. However, the island's dark past is reaching a breaking point, and Luffy and his crew are caught in the middle of the conflict.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>603-653 Fishman Island</title>
-  <year>2013</year>
+  <title>Fishman Island</title>
   <sorttitle>26</sorttitle>
-  <premiered>2013-04-07</premiered>
-  <releasedate>2013-04-07</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][603-653] Fishman Island [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>29</seasonnumber>
+  <displayseason>29</displayseason>
+  <plot>The path the to the New World takes the Straw Hats thousands of leagues under the sea to the underwater Fishman Island. However, the island's dark past is reaching a breaking point, and Luffy and his crew are caught in the middle of the conflict.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][654-699] Punk Hazard [720p]/season.nfo
+++ b/One Pace/[One Pace][654-699] Punk Hazard [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The first island of the New World is a strange place covered in flames on one half, and freezing temperatures on the other. What seems at first to be an unlivable place later reveals a laboratory, a maniac scientist, and a certain Warlord of the Sea.</plot>
-  <outline>The first island of the New World is a strange place covered in flames on one half, and freezing temperatures on the other. What seems at first to be an unlivable place later reveals a laboratory, a maniac scientist, and a certain Warlord of the Sea.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>654-699 Punk Hazard</title>
-  <year>2013</year>
+  <title>Punk Hazard</title>
   <sorttitle>27</sorttitle>
-  <premiered>2013-05-16</premiered>
-  <releasedate>2013-05-16</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][654-699] Punk Hazard [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>30</seasonnumber>
+  <displayseason>30</displayseason>
+  <plot>The first island of the New World is a strange place covered in flames on one half, and freezing temperatures on the other. What seems at first to be an unlivable place later reveals a laboratory, a maniac scientist, and a certain Warlord of the Sea.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][69-95] Arlong Park [1080p]/season.nfo
+++ b/One Pace/[One Pace][69-95] Arlong Park [1080p]/season.nfo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<season>
+  <title>Arlong Park</title>
+  <sorttitle>06</sorttitle>
+  <seasonnumber>7</seasonnumber>
+  <displayseason>7</displayseason>
+  <plot>Nami’s hometown has long been overrun by Arlong and his band of fishmen from the Grand Line. When the Straw Hats arrive, they find that their prospective navigator has left out a few key details about herself.</plot>
+  <lockdata>false</lockdata>
+</season>

--- a/One Pace/[One Pace][700-800] Dressrosa [720p]/season.nfo
+++ b/One Pace/[One Pace][700-800] Dressrosa [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Luffy's alliance with Law brings him next to Dressrosa to take down Doflamingo's booming business. But the crazed warlord and self-proclaimed ruler of Dressrosa has control over everyone and everything.</plot>
-  <outline>Luffy's alliance with Law brings him next to Dressrosa to take down Doflamingo's booming business. But the crazed warlord and self-proclaimed ruler of Dressrosa has control over everyone and everything.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>700-800 Dressrosa</title>
-  <year>2014</year>
+  <title>Dressrosa</title>
   <sorttitle>28</sorttitle>
-  <premiered>2014-02-09</premiered>
-  <releasedate>2014-02-09</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][700-800] Dressrosa [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>31</seasonnumber>
+  <displayseason>31</displayseason>
+  <plot>Luffy's alliance with Law brings him next to Dressrosa to take down Doflamingo's booming business. But the crazed warlord and self-proclaimed ruler of Dressrosa has control over everyone and everything.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][8-21] Orange Town [1080p]/season.nfo
+++ b/One Pace/[One Pace][8-21] Orange Town [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Orange Town</title>
+  <sorttitle>02</sorttitle>
+  <seasonnumber>2</seasonnumber>
+  <displayseason>2</displayseason>
   <plot>Luffy and Zoro run afoul of a flashy crew of pirates and their captain, Buggy the Clown. They are joined by a young girl named Nami who helps them navigate this predicament.</plot>
-  <outline>Luffy and Zoro run afoul of a flashy crew of pirates and their captain, Buggy the Clown. They are joined by a young girl named Nami who helps them navigate this predicament.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>8-21 Orange Town</title>
-  <sorttitle>2</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][8-21] Orange Town [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][801-822] Zou [720p]/season.nfo
+++ b/One Pace/[One Pace][801-822] Zou [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Zou cannot be reached by conventional means, nor is it easy to enter once one finds it. Within its secretive walls lie the Mink Tribe, and the Straw Hats soon discover that the people of Zou hold a piece of the puzzle that unlocks the mysteries of the world.</plot>
-  <outline>Zou cannot be reached by conventional means, nor is it easy to enter once one finds it. Within its secretive walls lie the Mink Tribe, and the Straw Hats soon discover that the people of Zou hold a piece of the puzzle that unlocks the mysteries of the world.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>801-822 Zou</title>
-  <year>2016</year>
+  <title>Zou</title>
   <sorttitle>29</sorttitle>
-  <premiered>2016-09-09</premiered>
-  <releasedate>2016-09-09</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][801-822] Zou [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>32</seasonnumber>
+  <displayseason>32</displayseason>
+  <plot>Zou cannot be reached by conventional means, nor is it easy to enter once one finds it. Within its secretive walls lie the Mink Tribe, and the Straw Hats soon discover that the people of Zou hold a piece of the puzzle that unlocks the mysteries of the world.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][823-902] Whole Cake Island [720p]/season.nfo
+++ b/One Pace/[One Pace][823-902] Whole Cake Island [720p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Luffy will not sail the seas without his cook, so he stubbornly goes after Sanji to Whole Cake Island. However, knocking on an emperor's door is easier said than done.</plot>
-  <outline>Luffy will not sail the seas without his cook, so he stubbornly goes after Sanji to Whole Cake Island. However, knocking on an emperor's door is easier said than done.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>823-902 Whole Cake Island</title>
-  <year>2018</year>
+  <title>Whole Cake Island</title>
   <sorttitle>30</sorttitle>
-  <premiered>2018-11-19</premiered>
-  <releasedate>2018-11-19</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][823-902] Whole Cake Island [720p]/folder.png</poster>
-  </art>
+  <seasonnumber>33</seasonnumber>
+  <displayseason>33</displayseason>
+  <plot>Luffy will not sail the seas without his cook, so he stubbornly goes after Sanji to Whole Cake Island. However, knocking on an emperor's door is easier said than done.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][83-119] The Trials of Koby-Meppo [1080p]/season.nfo
+++ b/One Pace/[One Pace][83-119] The Trials of Koby-Meppo [1080p]/season.nfo
@@ -1,12 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>The Trials of Koby-Meppo</title>
+  <sorttitle>06.5</sorttitle>
+  <seasonnumber>8</seasonnumber>
+  <displayseason>8</displayseason>
   <plot>Koby and Helmeppo are new cabin boys for the marines, but they become unwillingly involved in an escape attempt by Morgan. Their bravery will either earn them the respect of their superiors—as well as Vice Admiral Garp—or it will spell their doom.</plot>
-  <outline>Koby and Helmeppo are new cabin boys for the marines, but they become unwillingly involved in an escape attempt by Morgan. Their bravery will either earn them the respect of their superiors—as well as Vice Admiral Garp—or it will spell their doom.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>83-119 The Trials of Koby-Meppo</title>
-  <sorttitle>9.5</sorttitle>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][83-119] The Trials of Koby-Meppo [1080p]/folder.png</poster>
-  </art>
 </season>

--- a/One Pace/[One Pace][903-908] Reverie [1080p]/season.nfo
+++ b/One Pace/[One Pace][903-908] Reverie [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>Every four years, the leaders of the world gather at the Holy Land to discuss a mutually agreed upon path for the government. During this particular Reverie, many parties with their own agendas arrive... and some are uninvited.</plot>
-  <outline>Every four years, the leaders of the world gather at the Holy Land to discuss a mutually agreed upon path for the government. During this particular Reverie, many parties with their own agendas arrive... and some are uninvited.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>903-908 Reverie</title>
-  <year>2021</year>
+  <title>Reverie</title>
   <sorttitle>31</sorttitle>
-  <premiered>2021-01-02</premiered>
-  <releasedate>2021-01-02</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][903-908] Reverie [1080p]/folder.png</poster>
-  </art>
+  <seasonnumber>34</seasonnumber>
+  <displayseason>34</displayseason>
+  <plot>Every four years, the leaders of the world gather at the Holy Land to discuss a mutually agreed upon path for the government. During this particular Reverie, many parties with their own agendas arrive... and some are uninvited.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][909-1057] Wano [1080p]/season.nfo
+++ b/One Pace/[One Pace][909-1057] Wano [1080p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
-  <plot>The Straw Hats finally regroup in Wano to carry out theirs and their allies' ultimate goal: to see to the Emperor Kaido's downfall and restore the Kozuki family to its rightful place of power.</plot>
-  <outline>The Straw Hats finally regroup in Wano to carry out theirs and their allies' ultimate goal: to see to the Emperor Kaido's downfall and restore the Kozuki family to its rightful place of power.</outline>
-  <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>909-924 Wano Act 1</title>
-  <year>2020</year>
+  <title>Wano</title>
   <sorttitle>32</sorttitle>
-  <premiered>2020-04-06</premiered>
-  <releasedate>2020-04-06</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][909-924] Wano Act 1/folder.png</poster>
-  </art>
+  <seasonnumber>35</seasonnumber>
+  <displayseason>35</displayseason>
+  <plot>The Straw Hats finally regroup in Wano to carry out theirs and their allies' ultimate goal: to see to the Emperor Kaido's downfall and restore the Kozuki family to its rightful place of power.</plot>
+  <lockdata>false</lockdata>
 </season>

--- a/One Pace/[One Pace][96-100] Loguetown [480p]/season.nfo
+++ b/One Pace/[One Pace][96-100] Loguetown [480p]/season.nfo
@@ -1,15 +1,9 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <season>
+  <title>Loguetown</title>
+  <sorttitle>07</sorttitle>
+  <seasonnumber>9</seasonnumber>
+  <displayseason>9</displayseason>
   <plot>The final island before entering the Grand Line: Loguetown. Luffy and his crew drop anchor to stock up, sightsee, and pay their respects to the place where Gold Roger drew his last breath.</plot>
-  <outline>The final island before entering the Grand Line: Loguetown. Luffy and his crew drop anchor to stock up, sightsee, and pay their respects to the place where Gold Roger drew his last breath.</outline>
   <lockdata>false</lockdata>
-  <dateadded>2024-08-23 22:56:26</dateadded>
-  <title>96-100 Loguetown</title>
-  <year>2020</year>
-  <sorttitle>7</sorttitle>
-  <premiered>2020-09-22</premiered>
-  <releasedate>2020-09-22</releasedate>
-  <art>
-    <poster>/mnt/storage02/localplex02/onepace/One Pace/[One Pace][96-100] Loguetown [480p]/folder.png</poster>
-  </art>
 </season>


### PR DESCRIPTION
## What this PR adds

Complete `season.nfo` files for all 36 One Pace arcs, replacing the existing ones with an improved structure that resolves several known Jellyfin and Kodi display issues.

## Changes per season NFO

**New tags added:**
- `<seasonnumber>` — prevents Jellyfin from concatenating chapter numbers from the arc folder name into a spurious season number (e.g. Skypiea's `[237-303]` becoming "Season 237303")
- `<displayseason>` — integer for correct ordering in Kodi

**Existing tags improved:**
- `<title>` — clean arc name only (e.g. "Baratie"), removing the chapter range prefix (e.g. "42-68 Baratie")
- `<sorttitle>` — retained and zero-padded; cover story arcs use decimal notation (e.g. "03.5" for Buggy's Crew) to slot correctly between main arcs
- `<plot>` — existing IceToast plot text has been preserved where present; summaries added for arcs that previously had none

**Tags removed:**
- `<outline>` — Jellyfin ignores it
- `<art>` — hardcoded local paths that don't work on other systems; Jellyfin finds `folder.png` by convention without this tag
- `<dateadded>` — meaningless to other users

## Arc structure notes

This PR reflects the One Pace release structure as of April 2026. The episode metadata has been cross-referenced against current Nyaa releases and updated accordingly — this should represent a fully up-to-date set, though complete verification was not possible as the One Pace Discord is currently unavailable. Any gaps or inaccuracies are welcome as follow-up PRs.

Notable changes from the existing repo:
- **Baratie** updated to 8 episodes following upstream chapter renumbering
- **Dressrosa** episode filenames updated to current One Pace naming conventions
- **Gaimon** included as a standalone arc (sorttitle 04, displayseason 5), positioned between Buggy's Crew and Baratie
- Cover story arcs (Buggy's Crew, Koby-Meppo, Adventures of the Straw Hats) included with `.5` sorttitles

## Attribution

Season NFO structure and arc summaries were developed and stress-tested against a live Jellyfin and Kodi setup, with assistance from Claude Sonnet 4.6 (Anthropic).